### PR TITLE
Dedup store will now bypass deduplication when size is small

### DIFF
--- a/cas/store/tests/dedup_store_test.rs
+++ b/cas/store/tests/dedup_store_test.rs
@@ -47,8 +47,8 @@ mod dedup_store_tests {
         );
         let store = Pin::new(&store_owned);
 
-        let original_data = make_random_data(1 * MEGABYTE_SZ);
-        let digest = DigestInfo::try_new(&VALID_HASH1, 100).unwrap();
+        let original_data = make_random_data(MEGABYTE_SZ);
+        let digest = DigestInfo::try_new(&VALID_HASH1, MEGABYTE_SZ).unwrap();
 
         store
             .update(
@@ -79,8 +79,8 @@ mod dedup_store_tests {
         );
         let store = Pin::new(&store_owned);
 
-        let original_data = make_random_data(1 * MEGABYTE_SZ);
-        let digest = DigestInfo::try_new(&VALID_HASH1, 100).unwrap();
+        let original_data = make_random_data(MEGABYTE_SZ);
+        let digest = DigestInfo::try_new(&VALID_HASH1, MEGABYTE_SZ).unwrap();
 
         store
             .update(
@@ -95,9 +95,11 @@ mod dedup_store_tests {
         const LAST_CHUNK_HASH: &str = "9220cc441e3860a0a8f5ed984d5b2da69c09ca800dcfd7a93c755acf8561e7a5";
         const LAST_CHUNK_SIZE: usize = 25779;
 
-        content_store
+        let did_delete = content_store
             .remove_entry(&DigestInfo::try_new(LAST_CHUNK_HASH, LAST_CHUNK_SIZE).unwrap())
             .await;
+
+        assert_eq!(did_delete, true, "Expected item to exist in store");
 
         let result = store.get_part(digest.clone(), &mut vec![], 0, None).await;
         assert!(result.is_err(), "Expected result to be an error");
@@ -123,7 +125,7 @@ mod dedup_store_tests {
 
         const DATA_SIZE: usize = MEGABYTE_SZ / 4;
         let original_data = make_random_data(DATA_SIZE);
-        let digest = DigestInfo::try_new(&VALID_HASH1, 100).unwrap();
+        let digest = DigestInfo::try_new(&VALID_HASH1, DATA_SIZE).unwrap();
 
         store
             .update(

--- a/config/backends.rs
+++ b/config/backends.rs
@@ -84,7 +84,7 @@ pub struct DedupStore {
     /// because it will actually not check this number of bytes when
     /// deciding where to partition the data.
     ///
-    /// Default: 4096 (4k)
+    /// Default: 65536 (64k)
     #[serde(default)]
     pub min_size: u32,
 
@@ -92,13 +92,19 @@ pub struct DedupStore {
     /// of the chunks to this number. It is not a guarantee, but a
     /// slight attempt will be made.
     ///
-    /// Default: 16384 (16k)
+    /// This value will also be about the threshold used to determine
+    /// if we should even attempt to dedup the entry or just forward
+    /// it directly to the content_store without an index. The actual
+    /// value will be about `normal_size * 1.3` due to implementation
+    /// details.
+    ///
+    /// Default: 262144 (256k)
     #[serde(default)]
     pub normal_size: u32,
 
     /// Maximum size a chunk is allowed to be.
     ///
-    /// Default: 65536 (64k)
+    /// Default: 524288 (512k)
     #[serde(default)]
     pub max_size: u32,
 

--- a/config/examples/basic_cas.json
+++ b/config/examples/basic_cas.json
@@ -3,19 +3,35 @@
     "CAS_MAIN_STORE": {
       "verify": {
         "backend": {
-          "compression": {
-            "compression_algorithm": {
-              "LZ4": {}
-            },
-            "backend": {
+          "dedup": {
+            "index_store": {
               "s3_store": {
                 "region": "us-west-1",
                 "bucket": "blaisebruer-cas-store",
-                "key_prefix": "test-prefix-cas/",
+                "key_prefix": "test-prefix-index/",
                 "retry": {
                   "max_retries": 6,
                   "delay": 0.3,
                   "jitter": 0.5,
+                }
+              }
+            },
+            "content_store": {
+              "compression": {
+                "compression_algorithm": {
+                  "LZ4": {}
+                },
+                "backend": {
+                  "s3_store": {
+                    "region": "us-west-1",
+                    "bucket": "blaisebruer-cas-store",
+                    "key_prefix": "test-prefix-dedup-cas/",
+                    "retry": {
+                      "max_retries": 6,
+                      "delay": 0.3,
+                      "jitter": 0.5,
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
Also change the default values after some testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/rust_cas/17)
<!-- Reviewable:end -->
