### PR TITLE
`.has()` now returns size on success instead of boolean

### DIFF
--- a/cas/grpc_service/cas_server.rs
+++ b/cas/grpc_service/cas_server.rs
@@ -62,10 +62,10 @@ impl CasServer {
                 .clone();
             futures.push(tokio::spawn(async move {
                 let store = Pin::new(store_owned.as_ref());
-                store
-                    .has(digest.clone())
-                    .await
-                    .map_or_else(|_| None, |success| if success { None } else { Some(digest) })
+                store.has(digest.clone()).await.map_or_else(
+                    |_| None,
+                    |maybe_sz| if maybe_sz.is_some() { None } else { Some(digest) },
+                )
             }));
         }
         let mut responses = Vec::with_capacity(futures.len());

--- a/cas/store/compression_store.rs
+++ b/cas/store/compression_store.rs
@@ -220,7 +220,7 @@ impl CompressionStore {
 
 #[async_trait]
 impl StoreTrait for CompressionStore {
-    fn has<'a>(self: Pin<&'a Self>, digest: DigestInfo) -> ResultFuture<'a, bool> {
+    fn has<'a>(self: Pin<&'a Self>, digest: DigestInfo) -> ResultFuture<'a, Option<usize>> {
         Box::pin(async move { Pin::new(self.inner_store.as_ref()).has(digest).await })
     }
 

--- a/cas/store/dedup_store.rs
+++ b/cas/store/dedup_store.rs
@@ -103,7 +103,7 @@ impl DedupStore {
 
 #[async_trait]
 impl StoreTrait for DedupStore {
-    fn has<'a>(self: std::pin::Pin<&'a Self>, digest: DigestInfo) -> ResultFuture<'a, bool> {
+    fn has<'a>(self: std::pin::Pin<&'a Self>, digest: DigestInfo) -> ResultFuture<'a, Option<usize>> {
         Box::pin(async move { Pin::new(self.content_store.as_ref()).has(digest).await })
     }
 
@@ -143,7 +143,7 @@ impl StoreTrait for DedupStore {
 
                         let content_store_pin = Pin::new(content_store.as_ref());
                         let digest = DigestInfo::new(hash.clone().into(), frame.len() as i64);
-                        if content_store_pin.has(digest.clone()).await? {
+                        if content_store_pin.has(digest.clone()).await?.is_some() {
                             // If our store has this digest, we don't need to upload it.
                             return Ok(index_entry);
                         }

--- a/cas/store/memory_store.rs
+++ b/cas/store/memory_store.rs
@@ -35,10 +35,10 @@ impl MemoryStore {
 
 #[async_trait]
 impl StoreTrait for MemoryStore {
-    fn has<'a>(self: std::pin::Pin<&'a Self>, digest: DigestInfo) -> ResultFuture<'a, bool> {
+    fn has<'a>(self: std::pin::Pin<&'a Self>, digest: DigestInfo) -> ResultFuture<'a, Option<usize>> {
         Box::pin(async move {
             let mut map = self.map.lock().await;
-            Ok(map.contains_key(&digest))
+            Ok(map.size_for_key(&digest))
         })
     }
 

--- a/cas/store/store_trait.rs
+++ b/cas/store/store_trait.rs
@@ -32,7 +32,7 @@ pub enum UploadSizeInfo {
 
 #[async_trait]
 pub trait StoreTrait: Sync + Send + Unpin {
-    fn has<'a>(self: Pin<&'a Self>, digest: DigestInfo) -> ResultFuture<'a, bool>;
+    fn has<'a>(self: Pin<&'a Self>, digest: DigestInfo) -> ResultFuture<'a, Option<usize>>;
 
     fn update<'a>(
         self: Pin<&'a Self>,

--- a/cas/store/tests/memory_store_test.rs
+++ b/cas/store/tests/memory_store_test.rs
@@ -32,8 +32,9 @@ mod memory_store_tests {
                     UploadSizeInfo::ExactSize(VALUE1.len()),
                 )
                 .await?;
-            assert!(
-                store.has(DigestInfo::try_new(&VALID_HASH1, VALUE1.len())?).await?,
+            assert_eq!(
+                store.has(DigestInfo::try_new(&VALID_HASH1, VALUE1.len())?).await,
+                Ok(Some(VALUE1.len())),
                 "Expected memory store to have hash: {}",
                 VALID_HASH1
             );

--- a/cas/store/tests/s3_store_test.rs
+++ b/cas/store/tests/s3_store_test.rs
@@ -118,7 +118,7 @@ mod s3_store_tests {
     #[tokio::test]
     async fn simple_has_object_found() -> Result<(), Error> {
         let s3_client = S3Client::new_with(
-            MockRequestDispatcher::with_status(StatusCode::OK.into()),
+            MockRequestDispatcher::with_status(StatusCode::OK.into()).with_header("Content-Length", "512"),
             MockCredentialsProvider,
             Region::UsEast1,
         );
@@ -134,7 +134,7 @@ mod s3_store_tests {
 
         let digest = DigestInfo::try_new(&VALID_HASH1, 100).unwrap();
         let result = store_pin.has(digest.clone()).await;
-        assert_eq!(result, Ok(true), "Expected to find item, got: {:?}", result);
+        assert_eq!(result, Ok(Some(512)), "Expected to find item, got: {:?}", result);
         Ok(())
     }
 
@@ -166,7 +166,7 @@ mod s3_store_tests {
 
         let digest = DigestInfo::try_new(&VALID_HASH1, 100).unwrap();
         let result = store_pin.has(digest.clone()).await;
-        assert_eq!(result, Ok(false), "Expected to not find item, got: {:?}", result);
+        assert_eq!(result, Ok(None), "Expected to not find item, got: {:?}", result);
         Ok(())
     }
 
@@ -181,7 +181,7 @@ mod s3_store_tests {
                 // Dispatch errors are retried. Like timeouts.
                 MockRequestDispatcher::with_dispatch_error(HttpDispatchError::new("maybe timeout?".to_string())),
                 // Note: "OK" must always be last.
-                MockRequestDispatcher::with_status(StatusCode::OK.into()),
+                MockRequestDispatcher::with_status(StatusCode::OK.into()).with_header("Content-Length", "111"),
             ]),
             MockCredentialsProvider,
             Region::UsEast1,
@@ -203,7 +203,7 @@ mod s3_store_tests {
 
         let digest = DigestInfo::try_new(&VALID_HASH1, 100).unwrap();
         let result = store_pin.has(digest.clone()).await;
-        assert_eq!(result, Ok(true), "Expected to find item, got: {:?}", result);
+        assert_eq!(result, Ok(Some(111)), "Expected to find item, got: {:?}", result);
         Ok(())
     }
 

--- a/cas/store/tests/verify_store_test.rs
+++ b/cas/store/tests/verify_store_test.rs
@@ -50,8 +50,8 @@ mod verify_store_tests {
             result
         );
         assert_eq!(
-            Pin::new(inner_store.as_ref()).has(digest).await?,
-            true,
+            Pin::new(inner_store.as_ref()).has(digest).await,
+            Ok(Some(VALUE1.len())),
             "Expected data to exist in store after update"
         );
         Ok(())
@@ -89,8 +89,8 @@ mod verify_store_tests {
             err
         );
         assert_eq!(
-            Pin::new(inner_store.as_ref()).has(digest).await?,
-            false,
+            Pin::new(inner_store.as_ref()).has(digest).await,
+            Ok(None),
             "Expected data to not exist in store after update"
         );
         Ok(())
@@ -120,8 +120,8 @@ mod verify_store_tests {
             .await;
         assert_eq!(result, Ok(()), "Expected success, got: {:?}", result);
         assert_eq!(
-            Pin::new(inner_store.as_ref()).has(digest).await?,
-            true,
+            Pin::new(inner_store.as_ref()).has(digest).await,
+            Ok(Some(VALUE1.len())),
             "Expected data to exist in store after update"
         );
         Ok(())
@@ -156,8 +156,8 @@ mod verify_store_tests {
         let result = future.await.err_tip(|| "Failed to join spawn future")?;
         assert_eq!(result, Ok(()), "Expected success, got: {:?}", result);
         assert_eq!(
-            Pin::new(inner_store.as_ref()).has(digest).await?,
-            true,
+            Pin::new(inner_store.as_ref()).has(digest).await,
+            Ok(Some(6)),
             "Expected data to exist in store after update"
         );
         Ok(())
@@ -189,8 +189,8 @@ mod verify_store_tests {
             .await;
         assert_eq!(result, Ok(()), "Expected success, got: {:?}", result);
         assert_eq!(
-            Pin::new(inner_store.as_ref()).has(digest).await?,
-            true,
+            Pin::new(inner_store.as_ref()).has(digest).await,
+            Ok(Some(VALUE.len())),
             "Expected data to exist in store after update"
         );
         Ok(())
@@ -230,8 +230,8 @@ mod verify_store_tests {
             err
         );
         assert_eq!(
-            Pin::new(inner_store.as_ref()).has(digest).await?,
-            false,
+            Pin::new(inner_store.as_ref()).has(digest).await,
+            Ok(None),
             "Expected data to not exist in store after update"
         );
         Ok(())

--- a/cas/store/verify_store.rs
+++ b/cas/store/verify_store.rs
@@ -87,7 +87,7 @@ async fn inner_check_update<'a>(
 
 #[async_trait]
 impl StoreTrait for VerifyStore {
-    fn has<'a>(self: std::pin::Pin<&'a Self>, digest: DigestInfo) -> ResultFuture<'a, bool> {
+    fn has<'a>(self: std::pin::Pin<&'a Self>, digest: DigestInfo) -> ResultFuture<'a, Option<usize>> {
         Box::pin(async move { self.pin_inner().has(digest).await })
     }
 

--- a/util/evicting_map.rs
+++ b/util/evicting_map.rs
@@ -73,12 +73,12 @@ impl<T: InstantWrapper> EvictingMap<T> {
         }
     }
 
-    pub fn contains_key(&mut self, hash: &DigestInfo) -> bool {
+    pub fn size_for_key(&mut self, hash: &DigestInfo) -> Option<usize> {
         if let Some(mut entry) = self.lru.get_mut(hash) {
             entry.seconds_since_anchor = self.anchor_time.elapsed().as_secs() as u32;
-            return true;
+            return Some(entry.data.len());
         }
-        false
+        None
     }
 
     pub fn get<'a>(&'a mut self, hash: &DigestInfo) -> Option<&'a Arc<Vec<u8>>> {

--- a/util/tests/evicting_map_test.rs
+++ b/util/tests/evicting_map_test.rs
@@ -44,20 +44,24 @@ mod evicting_map_tests {
         evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(vec![]));
         evicting_map.insert(DigestInfo::try_new(HASH4, 0)?, Arc::new(vec![]));
 
-        assert!(
-            !evicting_map.contains_key(&DigestInfo::try_new(HASH1, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?),
+            None,
             "Expected map to not have item 1"
         );
-        assert!(
-            evicting_map.contains_key(&DigestInfo::try_new(HASH2, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH2, 0)?),
+            Some(0),
             "Expected map to have item 2"
         );
-        assert!(
-            evicting_map.contains_key(&DigestInfo::try_new(HASH3, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH3, 0)?),
+            Some(0),
             "Expected map to have item 3"
         );
-        assert!(
-            evicting_map.contains_key(&DigestInfo::try_new(HASH4, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH4, 0)?),
+            Some(0),
             "Expected map to have item 4"
         );
 
@@ -74,25 +78,30 @@ mod evicting_map_tests {
             },
             Instant::now(),
         );
-        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, Arc::new("12345678".into()));
-        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, Arc::new("12345678".into()));
-        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, Arc::new("12345678".into()));
-        evicting_map.insert(DigestInfo::try_new(HASH4, 0)?, Arc::new("12345678".into()));
+        const DATA: &str = "12345678";
+        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(DATA.into()));
+        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(DATA.into()));
+        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(DATA.into()));
+        evicting_map.insert(DigestInfo::try_new(HASH4, 0)?, Arc::new(DATA.into()));
 
-        assert!(
-            !evicting_map.contains_key(&DigestInfo::try_new(HASH1, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?),
+            None,
             "Expected map to not have item 1"
         );
-        assert!(
-            !evicting_map.contains_key(&DigestInfo::try_new(HASH2, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH2, 0)?),
+            None,
             "Expected map to not have item 2"
         );
-        assert!(
-            evicting_map.contains_key(&DigestInfo::try_new(HASH3, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH3, 0)?),
+            Some(DATA.len()),
             "Expected map to have item 3"
         );
-        assert!(
-            evicting_map.contains_key(&DigestInfo::try_new(HASH4, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH4, 0)?),
+            Some(DATA.len()),
             "Expected map to have item 4"
         );
 
@@ -110,28 +119,33 @@ mod evicting_map_tests {
             MockInstantWrapped(MockInstant::now()),
         );
 
-        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, Arc::new("12345678".into()));
+        const DATA: &str = "12345678";
+        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(DATA.into()));
         MockClock::advance(Duration::from_secs(2));
-        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, Arc::new("12345678".into()));
+        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(DATA.into()));
         MockClock::advance(Duration::from_secs(2));
-        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, Arc::new("12345678".into()));
+        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(DATA.into()));
         MockClock::advance(Duration::from_secs(2));
-        evicting_map.insert(DigestInfo::try_new(HASH4, 0)?, Arc::new("12345678".into()));
+        evicting_map.insert(DigestInfo::try_new(HASH4, 0)?, Arc::new(DATA.into()));
 
-        assert!(
-            !evicting_map.contains_key(&DigestInfo::try_new(HASH1, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?),
+            None,
             "Expected map to not have item 1"
         );
-        assert!(
-            evicting_map.contains_key(&DigestInfo::try_new(HASH2, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH2, 0)?),
+            Some(DATA.len()),
             "Expected map to have item 2"
         );
-        assert!(
-            evicting_map.contains_key(&DigestInfo::try_new(HASH3, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH3, 0)?),
+            Some(DATA.len()),
             "Expected map to have item 3"
         );
-        assert!(
-            evicting_map.contains_key(&DigestInfo::try_new(HASH4, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH4, 0)?),
+            Some(DATA.len()),
             "Expected map to have item 4"
         );
 
@@ -149,24 +163,28 @@ mod evicting_map_tests {
             MockInstantWrapped(MockInstant::now()),
         );
 
-        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, Arc::new("12345678".into()));
+        const DATA: &str = "12345678";
+        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(DATA.into()));
         MockClock::advance(Duration::from_secs(2));
-        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, Arc::new("12345678".into()));
+        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(DATA.into()));
         MockClock::advance(Duration::from_secs(2));
         evicting_map.get(&DigestInfo::try_new(HASH1, 0)?); // HASH1 should now be last to be evicted.
         MockClock::advance(Duration::from_secs(2));
-        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, Arc::new("12345678".into()));
+        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(DATA.into()));
 
-        assert!(
-            evicting_map.contains_key(&DigestInfo::try_new(HASH1, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?),
+            Some(DATA.len()),
             "Expected map to have item 1"
         );
-        assert!(
-            !evicting_map.contains_key(&DigestInfo::try_new(HASH2, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH2, 0)?),
+            None,
             "Expected map to not have item 2"
         );
-        assert!(
-            evicting_map.contains_key(&DigestInfo::try_new(HASH3, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH3, 0)?),
+            Some(DATA.len()),
             "Expected map to have item 3"
         );
 
@@ -184,24 +202,28 @@ mod evicting_map_tests {
             MockInstantWrapped(MockInstant::now()),
         );
 
-        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, Arc::new("12345678".into()));
+        const DATA: &str = "12345678";
+        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(DATA.into()));
         MockClock::advance(Duration::from_secs(2));
-        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, Arc::new("12345678".into()));
+        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(DATA.into()));
         MockClock::advance(Duration::from_secs(2));
-        evicting_map.contains_key(&DigestInfo::try_new(HASH1, 0)?); // HASH1 should now be last to be evicted.
+        evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?); // HASH1 should now be last to be evicted.
         MockClock::advance(Duration::from_secs(2));
-        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, Arc::new("12345678".into()));
+        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(DATA.into()));
 
-        assert!(
-            evicting_map.contains_key(&DigestInfo::try_new(HASH1, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?),
+            Some(8),
             "Expected map to have item 1"
         );
-        assert!(
-            !evicting_map.contains_key(&DigestInfo::try_new(HASH2, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH2, 0)?),
+            None,
             "Expected map to not have item 2"
         );
-        assert!(
-            evicting_map.contains_key(&DigestInfo::try_new(HASH3, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH3, 0)?),
+            Some(8),
             "Expected map to have item 3"
         );
 
@@ -223,12 +245,14 @@ mod evicting_map_tests {
         let value2: Arc<Vec<u8>> = Arc::new("87654321".into());
         evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, value1.clone());
         evicting_map.insert(DigestInfo::try_new(HASH1, 1)?, value2.clone());
-        assert!(
-            evicting_map.contains_key(&DigestInfo::try_new(HASH1, 0)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?),
+            Some(value1.len()),
             "HASH1/0 should exist"
         );
-        assert!(
-            evicting_map.contains_key(&DigestInfo::try_new(HASH1, 1)?),
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 1)?),
+            Some(value2.len()),
             "HASH1/1 should exist"
         );
 


### PR DESCRIPTION
We already have the size in each of our stores for the objects,
so we now return the size of the entry or None. This will make it
easier to implement certain features in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/rust_cas/19)
<!-- Reviewable:end -->
