### PR TITLE
Adds more eviction templates and functions in prep for filesystem store

### DIFF
--- a/cas/store/BUILD
+++ b/cas/store/BUILD
@@ -38,7 +38,6 @@ rust_library(
     srcs = ["memory_store.rs"],
     deps = [
         "//config",
-        "//third_party:fast_async_mutex",
         "//third_party:tokio",
         "//util:common",
         "//util:error",

--- a/util/BUILD
+++ b/util/BUILD
@@ -23,6 +23,7 @@ rust_library(
         "//third_party:hex",
         "//third_party:lazy_init",
         "//third_party:log",
+        "//third_party:serde",
         "//third_party:tokio",
         ":error",
     ],
@@ -45,7 +46,9 @@ rust_library(
     srcs = ["evicting_map.rs"],
     deps = [
         "//config",
+        "//third_party:fast_async_mutex",
         "//third_party:lru",
+        "//third_party:serde",
         "//util:common",
     ],
     visibility = ["//visibility:public"],

--- a/util/common.rs
+++ b/util/common.rs
@@ -11,6 +11,7 @@ use hex::FromHex;
 use lazy_init::LazyTransform;
 pub use log;
 use proto::build::bazel::remote::execution::v2::Digest;
+use serde::{Deserialize, Serialize};
 use tokio::task::{JoinError, JoinHandle};
 
 use error::{make_input_err, Error, ResultExt};
@@ -117,6 +118,19 @@ impl Into<Digest> for DigestInfo {
             size_bytes: self.size_bytes,
         }
     }
+}
+
+impl Into<DigestInfo> for SerializableDigestInfo {
+    fn into(self) -> DigestInfo {
+        DigestInfo::new(self.hash, self.size_bytes as i64)
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Default, Clone)]
+#[repr(C)]
+pub struct SerializableDigestInfo {
+    pub hash: [u8; 32],
+    pub size_bytes: u64,
 }
 
 /// Simple wrapper that will abort a future that is running in another spawn in the

--- a/util/evicting_map.rs
+++ b/util/evicting_map.rs
@@ -1,23 +1,43 @@
 // Copyright 2021 Nathan (Blaise) Bruer.  All rights reserved.
 
-use std::convert::TryInto;
+use std::ops::DerefMut;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use fast_async_mutex::mutex::Mutex;
 use lru::LruCache;
+use serde::{Deserialize, Serialize};
 
-use common::DigestInfo;
+use common::{DigestInfo, SerializableDigestInfo};
 use config::backends::EvictionPolicy;
+
+type LastTouchSinceAnchor = u32;
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct SerializedLRU {
+    pub data: Vec<(SerializableDigestInfo, LastTouchSinceAnchor)>,
+    pub anchor_time: u64,
+}
 
 /// Wrapper used to abstract away which underlying Instant impl we are using.
 /// This is needed for testing.
 pub trait InstantWrapper {
+    fn from_secs(secs: u64) -> Self;
+    fn unix_timestamp(&self) -> u64;
     fn elapsed(&self) -> Duration;
 }
 
-impl InstantWrapper for Instant {
+impl InstantWrapper for SystemTime {
+    fn from_secs(secs: u64) -> SystemTime {
+        SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs(secs)).unwrap()
+    }
+
+    fn unix_timestamp(&self) -> u64 {
+        self.duration_since(UNIX_EPOCH).unwrap().as_secs()
+    }
+
     fn elapsed(&self) -> Duration {
-        self.elapsed()
+        <SystemTime>::elapsed(self).unwrap()
     }
 }
 
@@ -27,7 +47,19 @@ struct EvictionItem<T: LenEntry> {
 }
 
 pub trait LenEntry {
+    // Length of referenced data.
     fn len(&self) -> usize;
+
+    // This will be called when object is removed from map.
+    // Note: There may still be a reference to it held somewhere else, which
+    // is why it can't be mutable. This is a good place to mark the item
+    // to be deleted and then in the Drop call actually do the deleting.
+    // This will ensure nowhere else in the program still holds a reference
+    // to this object.
+    // Note: You should not rely only on the Drop trait. Doing so might
+    // result in the program safely shutting down and calling the Drop method
+    // on each object, which if you are deleting items you may not want to do.
+    fn unref(&self) {}
 }
 
 impl LenEntry for Vec<u8> {
@@ -36,83 +68,147 @@ impl LenEntry for Vec<u8> {
     }
 }
 
-pub struct EvictingMap<T: LenEntry, I: InstantWrapper> {
+struct State<T: LenEntry> {
     lru: LruCache<DigestInfo, EvictionItem<T>>,
+    sum_store_size: u64,
+}
+
+pub struct EvictingMap<T: LenEntry, I: InstantWrapper> {
+    state: Mutex<State<T>>,
     anchor_time: I,
-    sum_store_size: usize,
-    max_bytes: usize,
+    max_bytes: u64,
     max_seconds: u32,
+    max_count: u64,
 }
 
 impl<T: LenEntry, I: InstantWrapper> EvictingMap<T, I> {
     pub fn new(config: &EvictionPolicy, anchor_time: I) -> Self {
-        let mut lru = LruCache::unbounded();
-        if config.max_count != 0 {
-            lru = LruCache::new(config.max_count.try_into().expect("Could not convert max_count to u64"));
-        }
         EvictingMap {
-            lru,
-            anchor_time: anchor_time,
-            sum_store_size: 0,
-            max_bytes: config.max_bytes,
+            // We use unbounded because if we use the bounded version we can't call the delete
+            // function on the LenEntry properly.
+            state: Mutex::new(State {
+                lru: LruCache::unbounded(),
+                sum_store_size: 0,
+            }),
+            anchor_time,
+            max_bytes: config.max_bytes as u64,
             max_seconds: config.max_seconds,
+            max_count: config.max_count,
         }
     }
 
-    fn evict_items(&mut self) {
-        // Remove items from map until size is less than max_bytes.
-        while self.max_bytes != 0 && self.sum_store_size >= self.max_bytes {
-            let (_, entry) = self.lru.pop_lru().expect("LRU became out of sync with sum_store_size");
-            self.sum_store_size -= entry.data.len();
+    pub async fn build_lru_index(&self) -> SerializedLRU {
+        let state = self.state.lock().await;
+        let mut serialized_lru = SerializedLRU {
+            data: Vec::with_capacity(state.lru.len()),
+            anchor_time: self.anchor_time.unix_timestamp(),
+        };
+        for (digest, eviction_item) in state.lru.iter() {
+            let serialized_digest = SerializableDigestInfo {
+                hash: digest.packed_hash,
+                size_bytes: digest.size_bytes as u64,
+            };
+            serialized_lru
+                .data
+                .push((serialized_digest, eviction_item.seconds_since_anchor));
         }
+        serialized_lru
+    }
 
-        // Zero means never evict based on time.
-        if self.max_seconds == 0 {
-            return;
+    pub async fn restore_lru(&mut self, seiralized_lru: SerializedLRU, entry_builder: impl Fn(&DigestInfo) -> Arc<T>) {
+        let mut state = self.state.lock().await;
+        self.anchor_time = I::from_secs(seiralized_lru.anchor_time);
+        state.lru.clear();
+        for (digest, seconds_since_anchor) in seiralized_lru.data {
+            let digest: DigestInfo = digest.into();
+            let entry = entry_builder(&digest);
+            state.lru.put(
+                digest,
+                EvictionItem {
+                    seconds_since_anchor,
+                    data: entry,
+                },
+            );
         }
+        // Just in case we allow for some cleanup (eg: old items).
+        self.evict_items(state.deref_mut());
+    }
 
-        // Remove items that are evicted based on time.
+    fn should_evict(&self, lru_len: usize, peek_entry: &EvictionItem<T>, sum_store_size: u64) -> bool {
+        let is_over_size = self.max_bytes != 0 && sum_store_size >= self.max_bytes;
+
         let evict_before_seconds =
             (self.anchor_time.elapsed().as_secs() as u32).max(self.max_seconds) - self.max_seconds;
-        while let Some((_, entry)) = self.lru.peek_lru() {
-            if entry.seconds_since_anchor >= evict_before_seconds {
-                break;
-            }
-            let (_, eviction_item) = self.lru.pop_lru().expect("Tried to peek() then pop() but failed");
-            self.sum_store_size -= eviction_item.data.len();
+        let old_item_exists = self.max_seconds != 0 && peek_entry.seconds_since_anchor < evict_before_seconds;
+
+        let is_over_count = self.max_count != 0 && (lru_len as u64) > self.max_count;
+
+        if is_over_size || old_item_exists || is_over_count {
+            return true;
+        }
+        false
+    }
+
+    fn evict_items(&self, state: &mut State<T>) {
+        let mut peek_entry = if let Some((_, entry)) = state.lru.peek_lru() {
+            entry
+        } else {
+            return;
+        };
+        while self.should_evict(state.lru.len(), peek_entry, state.sum_store_size) {
+            let (_, eviction_item) = state.lru.pop_lru().expect("Tried to peek() then pop() but failed");
+            state.sum_store_size -= eviction_item.data.len() as u64;
+            eviction_item.data.unref();
+
+            peek_entry = if let Some((_, entry)) = state.lru.peek_lru() {
+                entry
+            } else {
+                return;
+            };
         }
     }
 
-    pub fn size_for_key(&mut self, hash: &DigestInfo) -> Option<usize> {
-        if let Some(mut entry) = self.lru.get_mut(hash) {
+    pub async fn size_for_key(&self, digest: &DigestInfo) -> Option<usize> {
+        let mut state = self.state.lock().await;
+        if let Some(mut entry) = state.lru.get_mut(digest) {
             entry.seconds_since_anchor = self.anchor_time.elapsed().as_secs() as u32;
             return Some(entry.data.len());
         }
         None
     }
 
-    pub fn get<'a>(&'a mut self, hash: &DigestInfo) -> Option<&'a Arc<T>> {
-        if let Some(mut entry) = self.lru.get_mut(hash) {
+    pub async fn get(&self, digest: &DigestInfo) -> Option<Arc<T>> {
+        let mut state = self.state.lock().await;
+        if let Some(mut entry) = state.lru.get_mut(digest) {
             entry.seconds_since_anchor = self.anchor_time.elapsed().as_secs() as u32;
-            return Some(&entry.data);
+            return Some(entry.data.clone());
         }
         None
     }
 
-    pub fn insert(&mut self, hash: DigestInfo, data: Arc<T>) {
-        let new_item_size = data.len();
+    pub async fn insert(&self, digest: DigestInfo, data: Arc<T>) {
+        let new_item_size = data.len() as u64;
         let eviction_item = EvictionItem {
             seconds_since_anchor: self.anchor_time.elapsed().as_secs() as u32,
             data,
         };
-        if let Some(old_item) = self.lru.put(hash, eviction_item) {
-            self.sum_store_size -= old_item.data.len();
+        let mut state = self.state.lock().await;
+        if let Some(old_item) = state.lru.put(digest.into(), eviction_item) {
+            state.sum_store_size -= old_item.data.len() as u64;
+            old_item.data.unref();
         }
-        self.sum_store_size += new_item_size;
-        self.evict_items();
+        state.sum_store_size += new_item_size;
+        self.evict_items(state.deref_mut());
     }
 
-    pub fn remove(&mut self, hash: &DigestInfo) -> bool {
-        self.lru.pop(hash).is_some()
+    pub async fn remove(&self, digest: &DigestInfo) -> bool {
+        let mut state = self.state.lock().await;
+        if let Some(entry) = state.lru.pop(digest) {
+            state.sum_store_size -= entry.data.len() as u64;
+            drop(state);
+            entry.data.unref();
+            return true;
+        }
+        false
     }
 }

--- a/util/tests/evicting_map_test.rs
+++ b/util/tests/evicting_map_test.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 Nathan (Blaise) Bruer.  All rights reserved.
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use mock_instant::{Instant as MockInstant, MockClock};
 
@@ -15,6 +15,14 @@ use error::Error;
 struct MockInstantWrapped(MockInstant);
 
 impl InstantWrapper for MockInstantWrapped {
+    fn from_secs(_secs: u64) -> Self {
+        MockInstantWrapped(MockInstant::now())
+    }
+
+    fn unix_timestamp(&self) -> u64 {
+        100
+    }
+
     fn elapsed(&self) -> Duration {
         self.0.elapsed()
     }
@@ -31,36 +39,44 @@ mod evicting_map_tests {
 
     #[tokio::test]
     async fn insert_purges_at_max_count() -> Result<(), Error> {
-        let mut evicting_map = EvictingMap::<Vec<u8>, Instant>::new(
+        let evicting_map = EvictingMap::<Vec<u8>, MockInstantWrapped>::new(
             &EvictionPolicy {
                 max_count: 3,
                 max_seconds: 0,
                 max_bytes: 0,
             },
-            Instant::now(),
+            MockInstantWrapped(MockInstant::now()),
         );
-        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(vec![]));
-        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(vec![]));
-        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(vec![]));
-        evicting_map.insert(DigestInfo::try_new(HASH4, 0)?, Arc::new(vec![]));
+        evicting_map
+            .insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(vec![]))
+            .await;
+        evicting_map
+            .insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(vec![]))
+            .await;
+        evicting_map
+            .insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(vec![]))
+            .await;
+        evicting_map
+            .insert(DigestInfo::try_new(HASH4, 0)?, Arc::new(vec![]))
+            .await;
 
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?).await,
             None,
             "Expected map to not have item 1"
         );
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH2, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH2, 0)?).await,
             Some(0),
             "Expected map to have item 2"
         );
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH3, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH3, 0)?).await,
             Some(0),
             "Expected map to have item 3"
         );
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH4, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH4, 0)?).await,
             Some(0),
             "Expected map to have item 4"
         );
@@ -70,37 +86,45 @@ mod evicting_map_tests {
 
     #[tokio::test]
     async fn insert_purges_at_max_bytes() -> Result<(), Error> {
-        let mut evicting_map = EvictingMap::<Vec<u8>, Instant>::new(
+        let evicting_map = EvictingMap::<Vec<u8>, MockInstantWrapped>::new(
             &EvictionPolicy {
                 max_count: 0,
                 max_seconds: 0,
                 max_bytes: 17,
             },
-            Instant::now(),
+            MockInstantWrapped(MockInstant::now()),
         );
         const DATA: &str = "12345678";
-        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(DATA.into()));
-        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(DATA.into()));
-        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(DATA.into()));
-        evicting_map.insert(DigestInfo::try_new(HASH4, 0)?, Arc::new(DATA.into()));
+        evicting_map
+            .insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(DATA.into()))
+            .await;
+        evicting_map
+            .insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(DATA.into()))
+            .await;
+        evicting_map
+            .insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(DATA.into()))
+            .await;
+        evicting_map
+            .insert(DigestInfo::try_new(HASH4, 0)?, Arc::new(DATA.into()))
+            .await;
 
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?).await,
             None,
             "Expected map to not have item 1"
         );
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH2, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH2, 0)?).await,
             None,
             "Expected map to not have item 2"
         );
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH3, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH3, 0)?).await,
             Some(DATA.len()),
             "Expected map to have item 3"
         );
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH4, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH4, 0)?).await,
             Some(DATA.len()),
             "Expected map to have item 4"
         );
@@ -110,7 +134,7 @@ mod evicting_map_tests {
 
     #[tokio::test]
     async fn insert_purges_at_max_seconds() -> Result<(), Error> {
-        let mut evicting_map = EvictingMap::<Vec<u8>, MockInstantWrapped>::new(
+        let evicting_map = EvictingMap::<Vec<u8>, MockInstantWrapped>::new(
             &EvictionPolicy {
                 max_count: 0,
                 max_seconds: 5,
@@ -120,31 +144,39 @@ mod evicting_map_tests {
         );
 
         const DATA: &str = "12345678";
-        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(DATA.into()));
+        evicting_map
+            .insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(DATA.into()))
+            .await;
         MockClock::advance(Duration::from_secs(2));
-        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(DATA.into()));
+        evicting_map
+            .insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(DATA.into()))
+            .await;
         MockClock::advance(Duration::from_secs(2));
-        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(DATA.into()));
+        evicting_map
+            .insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(DATA.into()))
+            .await;
         MockClock::advance(Duration::from_secs(2));
-        evicting_map.insert(DigestInfo::try_new(HASH4, 0)?, Arc::new(DATA.into()));
+        evicting_map
+            .insert(DigestInfo::try_new(HASH4, 0)?, Arc::new(DATA.into()))
+            .await;
 
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?).await,
             None,
             "Expected map to not have item 1"
         );
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH2, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH2, 0)?).await,
             Some(DATA.len()),
             "Expected map to have item 2"
         );
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH3, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH3, 0)?).await,
             Some(DATA.len()),
             "Expected map to have item 3"
         );
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH4, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH4, 0)?).await,
             Some(DATA.len()),
             "Expected map to have item 4"
         );
@@ -154,7 +186,7 @@ mod evicting_map_tests {
 
     #[tokio::test]
     async fn get_refreshes_time() -> Result<(), Error> {
-        let mut evicting_map = EvictingMap::<Vec<u8>, MockInstantWrapped>::new(
+        let evicting_map = EvictingMap::<Vec<u8>, MockInstantWrapped>::new(
             &EvictionPolicy {
                 max_count: 0,
                 max_seconds: 3,
@@ -164,26 +196,32 @@ mod evicting_map_tests {
         );
 
         const DATA: &str = "12345678";
-        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(DATA.into()));
+        evicting_map
+            .insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(DATA.into()))
+            .await;
         MockClock::advance(Duration::from_secs(2));
-        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(DATA.into()));
+        evicting_map
+            .insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(DATA.into()))
+            .await;
         MockClock::advance(Duration::from_secs(2));
-        evicting_map.get(&DigestInfo::try_new(HASH1, 0)?); // HASH1 should now be last to be evicted.
+        evicting_map.get(&DigestInfo::try_new(HASH1, 0)?).await; // HASH1 should now be last to be evicted.
         MockClock::advance(Duration::from_secs(2));
-        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(DATA.into()));
+        evicting_map
+            .insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(DATA.into()))
+            .await;
 
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?).await,
             Some(DATA.len()),
             "Expected map to have item 1"
         );
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH2, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH2, 0)?).await,
             None,
             "Expected map to not have item 2"
         );
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH3, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH3, 0)?).await,
             Some(DATA.len()),
             "Expected map to have item 3"
         );
@@ -193,7 +231,7 @@ mod evicting_map_tests {
 
     #[tokio::test]
     async fn contains_key_refreshes_time() -> Result<(), Error> {
-        let mut evicting_map = EvictingMap::<Vec<u8>, MockInstantWrapped>::new(
+        let evicting_map = EvictingMap::<Vec<u8>, MockInstantWrapped>::new(
             &EvictionPolicy {
                 max_count: 0,
                 max_seconds: 3,
@@ -203,26 +241,32 @@ mod evicting_map_tests {
         );
 
         const DATA: &str = "12345678";
-        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(DATA.into()));
+        evicting_map
+            .insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(DATA.into()))
+            .await;
         MockClock::advance(Duration::from_secs(2));
-        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(DATA.into()));
+        evicting_map
+            .insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(DATA.into()))
+            .await;
         MockClock::advance(Duration::from_secs(2));
-        evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?); // HASH1 should now be last to be evicted.
+        evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?).await; // HASH1 should now be last to be evicted.
         MockClock::advance(Duration::from_secs(2));
-        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(DATA.into()));
+        evicting_map
+            .insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(DATA.into()))
+            .await;
 
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?).await,
             Some(8),
             "Expected map to have item 1"
         );
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH2, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH2, 0)?).await,
             None,
             "Expected map to not have item 2"
         );
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH3, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH3, 0)?).await,
             Some(8),
             "Expected map to have item 3"
         );
@@ -232,32 +276,108 @@ mod evicting_map_tests {
 
     #[tokio::test]
     async fn hashes_equal_sizes_different_doesnt_override() -> Result<(), Error> {
-        let mut evicting_map = EvictingMap::<Vec<u8>, Instant>::new(
+        let evicting_map = EvictingMap::<Vec<u8>, MockInstantWrapped>::new(
             &EvictionPolicy {
                 max_count: 0,
                 max_seconds: 0,
                 max_bytes: 0,
             },
-            Instant::now(),
+            MockInstantWrapped(MockInstant::now()),
         );
 
         let value1: Arc<Vec<u8>> = Arc::new("12345678".into());
         let value2: Arc<Vec<u8>> = Arc::new("87654321".into());
-        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, value1.clone());
-        evicting_map.insert(DigestInfo::try_new(HASH1, 1)?, value2.clone());
+        evicting_map
+            .insert(DigestInfo::try_new(HASH1, 0)?, value1.clone())
+            .await;
+        evicting_map
+            .insert(DigestInfo::try_new(HASH1, 1)?, value2.clone())
+            .await;
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?).await,
             Some(value1.len()),
             "HASH1/0 should exist"
         );
         assert_eq!(
-            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 1)?),
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 1)?).await,
             Some(value2.len()),
             "HASH1/1 should exist"
         );
 
-        assert_eq!(*evicting_map.get(&DigestInfo::try_new(HASH1, 0)?).unwrap(), value1);
-        assert_eq!(*evicting_map.get(&DigestInfo::try_new(HASH1, 1)?).unwrap(), value2);
+        assert_eq!(evicting_map.get(&DigestInfo::try_new(HASH1, 0)?).await.unwrap(), value1);
+        assert_eq!(evicting_map.get(&DigestInfo::try_new(HASH1, 1)?).await.unwrap(), value2);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn build_lru_index_and_reload() -> Result<(), Error> {
+        let mut evicting_map = EvictingMap::<Vec<u8>, MockInstantWrapped>::new(
+            &EvictionPolicy {
+                max_count: 0,
+                max_seconds: 0,
+                max_bytes: 0,
+            },
+            MockInstantWrapped(MockInstant::now()),
+        );
+
+        let value1: Arc<Vec<u8>> = Arc::new(vec![]);
+        let value2: Arc<Vec<u8>> = Arc::new(vec![]);
+        evicting_map
+            .insert(DigestInfo::try_new(HASH1, 0)?, value1.clone())
+            .await;
+        evicting_map
+            .insert(DigestInfo::try_new(HASH2, 1)?, value2.clone())
+            .await;
+
+        let serialized_index = evicting_map.build_lru_index().await;
+
+        {
+            // Now insert another entry.
+            let value3: Arc<Vec<u8>> = Arc::new(vec![]);
+            evicting_map
+                .insert(DigestInfo::try_new(HASH3, 3)?, value3.clone())
+                .await;
+
+            assert_eq!(
+                evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?).await,
+                Some(value1.len()),
+                "HASH1/0 should exist"
+            );
+            assert_eq!(
+                evicting_map.size_for_key(&DigestInfo::try_new(HASH2, 1)?).await,
+                Some(value2.len()),
+                "HASH2/1 should exist"
+            );
+            assert_eq!(
+                evicting_map.size_for_key(&DigestInfo::try_new(HASH3, 3)?).await,
+                Some(value3.len()),
+                "HASH3/1 should exist"
+            );
+        }
+
+        // Now reload from the serialized version.
+        evicting_map
+            .restore_lru(serialized_index, move |_digest| Arc::new(vec![]))
+            .await;
+
+        // Data should now have the previously inserted data, but not the newly inserted data
+        // that was inserted after the `build_lru_index` call.
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?).await,
+            Some(value1.len()),
+            "HASH1/0 should exist"
+        );
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH2, 1)?).await,
+            Some(value2.len()),
+            "HASH2/1 should exist"
+        );
+        assert_eq!(
+            evicting_map.size_for_key(&DigestInfo::try_new(HASH3, 3)?).await,
+            None,
+            "HASH3/2 should be empty"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Adds ability to snapshot the eviction map and restore it. Also adds some
deref() functions that will eventually be used to delete files when needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/rust_cas/23)
<!-- Reviewable:end -->
