### PR TITLE
Move evicting_map to use bytes instead of Vec for future efficencies

### DIFF
--- a/cas/store/memory_store.rs
+++ b/cas/store/memory_store.rs
@@ -1,7 +1,6 @@
 // Copyright 2020-2021 Nathan (Blaise) Bruer.  All rights reserved.
 
 use std::marker::Send;
-use std::sync::Arc;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
@@ -51,7 +50,7 @@ impl StoreTrait for MemoryStore {
             let mut buffer = Vec::with_capacity(max_size);
             reader.read_to_end(&mut buffer).await?;
             buffer.shrink_to_fit();
-            self.map.insert(digest, Arc::new(buffer)).await;
+            self.map.insert(digest, buffer).await;
             Ok(())
         })
     }

--- a/util/BUILD
+++ b/util/BUILD
@@ -121,6 +121,7 @@ rust_test(
     srcs = ["tests/evicting_map_test.rs"],
     deps = [
         "//config",
+        "//third_party:bytes",
         "//third_party:hex",
         "//third_party:mock_instant",
         "//third_party:tokio",

--- a/util/tests/evicting_map_test.rs
+++ b/util/tests/evicting_map_test.rs
@@ -1,15 +1,14 @@
 // Copyright 2021 Nathan (Blaise) Bruer.  All rights reserved.
 
-use std::sync::Arc;
 use std::time::Duration;
 
+use bytes::Bytes;
 use mock_instant::{Instant as MockInstant, MockClock};
 
 use common::DigestInfo;
 use config::backends::EvictionPolicy;
-use evicting_map::{EvictingMap, InstantWrapper};
-
 use error::Error;
+use evicting_map::{EvictingMap, InstantWrapper};
 
 /// Our mocked out instant that we can pass to our EvictionMap.
 struct MockInstantWrapped(MockInstant);
@@ -39,7 +38,7 @@ mod evicting_map_tests {
 
     #[tokio::test]
     async fn insert_purges_at_max_count() -> Result<(), Error> {
-        let evicting_map = EvictingMap::<Vec<u8>, MockInstantWrapped>::new(
+        let evicting_map = EvictingMap::<Bytes, MockInstantWrapped>::new(
             &EvictionPolicy {
                 max_count: 3,
                 max_seconds: 0,
@@ -47,18 +46,10 @@ mod evicting_map_tests {
             },
             MockInstantWrapped(MockInstant::now()),
         );
-        evicting_map
-            .insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(vec![]))
-            .await;
-        evicting_map
-            .insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(vec![]))
-            .await;
-        evicting_map
-            .insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(vec![]))
-            .await;
-        evicting_map
-            .insert(DigestInfo::try_new(HASH4, 0)?, Arc::new(vec![]))
-            .await;
+        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, Bytes::new()).await;
+        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, Bytes::new()).await;
+        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, Bytes::new()).await;
+        evicting_map.insert(DigestInfo::try_new(HASH4, 0)?, Bytes::new()).await;
 
         assert_eq!(
             evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?).await,
@@ -86,7 +77,7 @@ mod evicting_map_tests {
 
     #[tokio::test]
     async fn insert_purges_at_max_bytes() -> Result<(), Error> {
-        let evicting_map = EvictingMap::<Vec<u8>, MockInstantWrapped>::new(
+        let evicting_map = EvictingMap::<Bytes, MockInstantWrapped>::new(
             &EvictionPolicy {
                 max_count: 0,
                 max_seconds: 0,
@@ -95,18 +86,10 @@ mod evicting_map_tests {
             MockInstantWrapped(MockInstant::now()),
         );
         const DATA: &str = "12345678";
-        evicting_map
-            .insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(DATA.into()))
-            .await;
-        evicting_map
-            .insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(DATA.into()))
-            .await;
-        evicting_map
-            .insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(DATA.into()))
-            .await;
-        evicting_map
-            .insert(DigestInfo::try_new(HASH4, 0)?, Arc::new(DATA.into()))
-            .await;
+        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, DATA.into()).await;
+        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, DATA.into()).await;
+        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, DATA.into()).await;
+        evicting_map.insert(DigestInfo::try_new(HASH4, 0)?, DATA.into()).await;
 
         assert_eq!(
             evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?).await,
@@ -134,7 +117,7 @@ mod evicting_map_tests {
 
     #[tokio::test]
     async fn insert_purges_at_max_seconds() -> Result<(), Error> {
-        let evicting_map = EvictingMap::<Vec<u8>, MockInstantWrapped>::new(
+        let evicting_map = EvictingMap::<Bytes, MockInstantWrapped>::new(
             &EvictionPolicy {
                 max_count: 0,
                 max_seconds: 5,
@@ -144,21 +127,13 @@ mod evicting_map_tests {
         );
 
         const DATA: &str = "12345678";
-        evicting_map
-            .insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(DATA.into()))
-            .await;
+        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, DATA.into()).await;
         MockClock::advance(Duration::from_secs(2));
-        evicting_map
-            .insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(DATA.into()))
-            .await;
+        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, DATA.into()).await;
         MockClock::advance(Duration::from_secs(2));
-        evicting_map
-            .insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(DATA.into()))
-            .await;
+        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, DATA.into()).await;
         MockClock::advance(Duration::from_secs(2));
-        evicting_map
-            .insert(DigestInfo::try_new(HASH4, 0)?, Arc::new(DATA.into()))
-            .await;
+        evicting_map.insert(DigestInfo::try_new(HASH4, 0)?, DATA.into()).await;
 
         assert_eq!(
             evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?).await,
@@ -186,7 +161,7 @@ mod evicting_map_tests {
 
     #[tokio::test]
     async fn get_refreshes_time() -> Result<(), Error> {
-        let evicting_map = EvictingMap::<Vec<u8>, MockInstantWrapped>::new(
+        let evicting_map = EvictingMap::<Bytes, MockInstantWrapped>::new(
             &EvictionPolicy {
                 max_count: 0,
                 max_seconds: 3,
@@ -196,19 +171,13 @@ mod evicting_map_tests {
         );
 
         const DATA: &str = "12345678";
-        evicting_map
-            .insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(DATA.into()))
-            .await;
+        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, DATA.into()).await;
         MockClock::advance(Duration::from_secs(2));
-        evicting_map
-            .insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(DATA.into()))
-            .await;
+        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, DATA.into()).await;
         MockClock::advance(Duration::from_secs(2));
         evicting_map.get(&DigestInfo::try_new(HASH1, 0)?).await; // HASH1 should now be last to be evicted.
         MockClock::advance(Duration::from_secs(2));
-        evicting_map
-            .insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(DATA.into()))
-            .await;
+        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, DATA.into()).await;
 
         assert_eq!(
             evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?).await,
@@ -231,7 +200,7 @@ mod evicting_map_tests {
 
     #[tokio::test]
     async fn contains_key_refreshes_time() -> Result<(), Error> {
-        let evicting_map = EvictingMap::<Vec<u8>, MockInstantWrapped>::new(
+        let evicting_map = EvictingMap::<Bytes, MockInstantWrapped>::new(
             &EvictionPolicy {
                 max_count: 0,
                 max_seconds: 3,
@@ -241,19 +210,13 @@ mod evicting_map_tests {
         );
 
         const DATA: &str = "12345678";
-        evicting_map
-            .insert(DigestInfo::try_new(HASH1, 0)?, Arc::new(DATA.into()))
-            .await;
+        evicting_map.insert(DigestInfo::try_new(HASH1, 0)?, DATA.into()).await;
         MockClock::advance(Duration::from_secs(2));
-        evicting_map
-            .insert(DigestInfo::try_new(HASH2, 0)?, Arc::new(DATA.into()))
-            .await;
+        evicting_map.insert(DigestInfo::try_new(HASH2, 0)?, DATA.into()).await;
         MockClock::advance(Duration::from_secs(2));
         evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?).await; // HASH1 should now be last to be evicted.
         MockClock::advance(Duration::from_secs(2));
-        evicting_map
-            .insert(DigestInfo::try_new(HASH3, 0)?, Arc::new(DATA.into()))
-            .await;
+        evicting_map.insert(DigestInfo::try_new(HASH3, 0)?, DATA.into()).await;
 
         assert_eq!(
             evicting_map.size_for_key(&DigestInfo::try_new(HASH1, 0)?).await,
@@ -276,7 +239,7 @@ mod evicting_map_tests {
 
     #[tokio::test]
     async fn hashes_equal_sizes_different_doesnt_override() -> Result<(), Error> {
-        let evicting_map = EvictingMap::<Vec<u8>, MockInstantWrapped>::new(
+        let evicting_map = EvictingMap::<Bytes, MockInstantWrapped>::new(
             &EvictionPolicy {
                 max_count: 0,
                 max_seconds: 0,
@@ -285,8 +248,8 @@ mod evicting_map_tests {
             MockInstantWrapped(MockInstant::now()),
         );
 
-        let value1: Arc<Vec<u8>> = Arc::new("12345678".into());
-        let value2: Arc<Vec<u8>> = Arc::new("87654321".into());
+        let value1 = Bytes::from_static(b"12345678");
+        let value2 = Bytes::from_static(b"87654321");
         evicting_map
             .insert(DigestInfo::try_new(HASH1, 0)?, value1.clone())
             .await;
@@ -312,7 +275,7 @@ mod evicting_map_tests {
 
     #[tokio::test]
     async fn build_lru_index_and_reload() -> Result<(), Error> {
-        let mut evicting_map = EvictingMap::<Vec<u8>, MockInstantWrapped>::new(
+        let mut evicting_map = EvictingMap::<Bytes, MockInstantWrapped>::new(
             &EvictionPolicy {
                 max_count: 0,
                 max_seconds: 0,
@@ -321,8 +284,8 @@ mod evicting_map_tests {
             MockInstantWrapped(MockInstant::now()),
         );
 
-        let value1: Arc<Vec<u8>> = Arc::new(vec![]);
-        let value2: Arc<Vec<u8>> = Arc::new(vec![]);
+        let value1 = Bytes::new();
+        let value2 = Bytes::new();
         evicting_map
             .insert(DigestInfo::try_new(HASH1, 0)?, value1.clone())
             .await;
@@ -334,7 +297,7 @@ mod evicting_map_tests {
 
         {
             // Now insert another entry.
-            let value3: Arc<Vec<u8>> = Arc::new(vec![]);
+            let value3 = Bytes::new();
             evicting_map
                 .insert(DigestInfo::try_new(HASH3, 3)?, value3.clone())
                 .await;
@@ -358,7 +321,7 @@ mod evicting_map_tests {
 
         // Now reload from the serialized version.
         evicting_map
-            .restore_lru(serialized_index, move |_digest| Arc::new(vec![]))
+            .restore_lru(serialized_index, move |_digest| Bytes::new())
             .await;
 
         // Data should now have the previously inserted data, but not the newly inserted data


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/rust_cas/26)
<!-- Reviewable:end -->
