### PR TITLE
Fix bug during .has() call in dedup store

### DIFF
--- a/cas/cas_main.rs
+++ b/cas/cas_main.rs
@@ -47,7 +47,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .unwrap();
     }
 
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("error"))
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
         .format_timestamp_millis()
         .init();
 

--- a/cas/grpc_service/bytestream_server.rs
+++ b/cas/grpc_service/bytestream_server.rs
@@ -111,6 +111,7 @@ impl ByteStreamServer {
                         return Some((Err(err.into()), None));
                     }
                     let response = ReadResponse { data: bytes };
+                    log::debug!("\x1b[0;31mBytestream Read Chunk Resp\x1b[0m: {:?}", response);
                     Some((Ok(response), Some(state)))
                 }
                 Err(mut e) => {
@@ -127,6 +128,7 @@ impl ByteStreamServer {
                         // message as it will be the most relevant.
                         e.messages.resize_with(1, || "".to_string());
                     }
+                    log::debug!("\x1b[0;31mBytestream Read Chunk Resp\x1b[0m: Error {:?}", e);
                     Some((Err(e.into()), None))
                 }
             }

--- a/cas/grpc_service/cas_server.rs
+++ b/cas/grpc_service/cas_server.rs
@@ -62,8 +62,15 @@ impl CasServer {
             futures.push(tokio::spawn(async move {
                 let store = Pin::new(store_owned.as_ref());
                 store.has(digest.clone()).await.map_or_else(
-                    |_| None,
-                    |maybe_sz| if maybe_sz.is_some() { None } else { Some(digest) },
+                    |e| {
+                        log::error!(
+                            "Error during .has() call in .find_missing_blobs() : {:?} - {}",
+                            e,
+                            digest.str()
+                        );
+                        Some(digest.clone())
+                    },
+                    |maybe_sz| if maybe_sz.is_some() { None } else { Some(digest.clone()) },
                 )
             }));
         }

--- a/config/backends.rs
+++ b/config/backends.rs
@@ -106,6 +106,7 @@ pub struct FilesystemStore {
     /// Buffer size to use when reading files. Generally this should be left
     /// to the default value except for testing.
     /// Default: 32k.
+    #[serde(default)]
     pub read_buffer_size: u32,
 
     /// Policy used to evict items out of the store. Failure to set this

--- a/config/examples/filesystem_cas.json
+++ b/config/examples/filesystem_cas.json
@@ -21,8 +21,8 @@
                 },
                 "backend": {
                   "filesystem": {
-                    "content_path": "/tmp/rust_cas_data/content_path-content",
-                    "temp_path": "/tmp/rust_cas_data/tmp_path-content",
+                    "content_path": "/tmp/rust_cas_data/content_path-cas",
+                    "temp_path": "/tmp/rust_cas_data/tmp_path-cas",
                     "eviction_policy": {
                       // 2gb.
                       "max_bytes": 2000000000,


### PR DESCRIPTION
Fixes a bug in dedup store where because .has() call would call
.get_part() internally, if the part did not exist it would return
Code::NotFound as an error. When dealing with .get_part() this is
the proper thing to do, but .has() calls are supposed to return
None when object does not exist.

Also added following minor changes:
* Better debug messages when this happens
* filesystem_cas.json now uses dedup store by default

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/rust_cas/43)
<!-- Reviewable:end -->
