### PR TITLE
Add RefStore and restructure StoreManager

### DIFF
--- a/cas/BUILD
+++ b/cas/BUILD
@@ -13,6 +13,7 @@ rust_binary(
         "//cas/grpc_service:cas_server",
         "//cas/grpc_service:execution_server",
         "//cas/store",
+        "//cas/store:default_store_factory",
         "//config",
         "//third_party:clap",
         "//third_party:env_logger",

--- a/cas/grpc_service/BUILD
+++ b/cas/grpc_service/BUILD
@@ -107,6 +107,7 @@ rust_test(
     srcs = ["tests/cas_server_test.rs"],
     deps = [
         "//cas/store",
+        "//cas/store:default_store_factory",
         "//config",
         "//proto",
         "//third_party:maplit",
@@ -124,6 +125,7 @@ rust_test(
     srcs = ["tests/ac_server_test.rs"],
     deps = [
         "//cas/store",
+        "//cas/store:default_store_factory",
         "//config",
         "//proto",
         "//third_party:bytes",
@@ -143,6 +145,7 @@ rust_test(
     srcs = ["tests/bytestream_server_test.rs"],
     deps = [
         "//cas/store",
+        "//cas/store:default_store_factory",
         "//config",
         "//proto",
         "//third_party:futures",

--- a/cas/grpc_service/ac_server.rs
+++ b/cas/grpc_service/ac_server.rs
@@ -30,8 +30,7 @@ impl AcServer {
         for (instance_name, ac_cfg) in config {
             let store = store_manager
                 .get_store(&ac_cfg.ac_store)
-                .ok_or_else(|| make_input_err!("'ac_store': '{}' does not exist", ac_cfg.ac_store))?
-                .clone();
+                .ok_or_else(|| make_input_err!("'ac_store': '{}' does not exist", ac_cfg.ac_store))?;
             stores.insert(instance_name.to_string(), store);
         }
         Ok(AcServer { stores: stores.clone() })

--- a/cas/grpc_service/bytestream_server.rs
+++ b/cas/grpc_service/bytestream_server.rs
@@ -41,8 +41,7 @@ impl ByteStreamServer {
         for (instance_name, store_name) in &config.cas_stores {
             let store = store_manager
                 .get_store(&store_name)
-                .ok_or_else(|| make_input_err!("'cas_store': '{}' does not exist", store_name))?
-                .clone();
+                .ok_or_else(|| make_input_err!("'cas_store': '{}' does not exist", store_name))?;
             stores.insert(instance_name.to_string(), store);
         }
         Ok(ByteStreamServer {

--- a/cas/grpc_service/cas_server.rs
+++ b/cas/grpc_service/cas_server.rs
@@ -34,8 +34,7 @@ impl CasServer {
         for (instance_name, cas_cfg) in config {
             let store = store_manager
                 .get_store(&cas_cfg.cas_store)
-                .ok_or_else(|| make_input_err!("'cas_store': '{}' does not exist", cas_cfg.cas_store))?
-                .clone();
+                .ok_or_else(|| make_input_err!("'cas_store': '{}' does not exist", cas_cfg.cas_store))?;
             stores.insert(instance_name.to_string(), store);
         }
         Ok(CasServer { stores: stores })

--- a/cas/grpc_service/execution_server.rs
+++ b/cas/grpc_service/execution_server.rs
@@ -113,8 +113,7 @@ impl ExecutionServer {
                 .err_tip(|| "Capabilities needs config for '{}' because it exists in execution")?;
             let cas_store = store_manager
                 .get_store(&exec_cfg.cas_store)
-                .ok_or_else(|| make_input_err!("'cas_store': '{}' does not exist", exec_cfg.cas_store))?
-                .clone();
+                .ok_or_else(|| make_input_err!("'cas_store': '{}' does not exist", exec_cfg.cas_store))?;
             let platform_property_manager = PlatformPropertyManager::new(
                 capabilities_cfg
                     .supported_platform_properties

--- a/cas/store/BUILD
+++ b/cas/store/BUILD
@@ -7,6 +7,17 @@ rust_library(
     srcs = ["lib.rs"],
     deps = [
         "//config",
+        "//util:error",
+        ":traits",
+    ],
+    visibility = ["//cas:__pkg__", "//cas:__subpackages__"]
+)
+
+rust_library(
+    name = "default_store_factory",
+    srcs = ["default_store_factory.rs"],
+    deps = [
+        "//config",
         "//third_party:futures",
         "//util:error",
         ":compression_store",
@@ -14,7 +25,9 @@ rust_library(
         ":fast_slow_store",
         ":filesystem_store",
         ":memory_store",
+        ":ref_store",
         ":s3_store",
+        ":store",
         ":traits",
         ":verify_store",
     ],
@@ -31,6 +44,21 @@ rust_library(
         "//util:buf_channel",
         "//util:common",
         "//util:error",
+    ],
+    proc_macro_deps = ["//third_party:async_trait"],
+    visibility = ["//cas:__pkg__"]
+)
+
+rust_library(
+    name = "ref_store",
+    srcs = ["ref_store.rs"],
+    deps = [
+        "//config",
+        "//util:buf_channel",
+        "//util:common",
+        "//util:error",
+        ":store",
+        ":traits",
     ],
     proc_macro_deps = ["//third_party:async_trait"],
     visibility = ["//cas:__pkg__"]
@@ -171,6 +199,21 @@ rust_library(
     ],
     proc_macro_deps = ["//third_party:async_trait"],
     visibility = ["//cas:__pkg__"]
+)
+
+rust_test(
+    name = "ref_store_test",
+    srcs = ["tests/ref_store_test.rs"],
+    deps = [
+        "//config",
+        "//third_party:pretty_assertions",
+        "//third_party:tokio",
+        "//util:common",
+        "//util:error",
+        ":memory_store",
+        ":ref_store",
+        ":store",
+    ],
 )
 
 rust_test(

--- a/cas/store/default_store_factory.rs
+++ b/cas/store/default_store_factory.rs
@@ -1,0 +1,50 @@
+// Copyright 2022 Nathan (Blaise) Bruer.  All rights reserved.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use compression_store::CompressionStore;
+use config::{self, backends::StoreConfig};
+use dedup_store::DedupStore;
+use error::Error;
+use fast_slow_store::FastSlowStore;
+use filesystem_store::FilesystemStore;
+use futures::Future;
+use memory_store::MemoryStore;
+use ref_store::RefStore;
+use s3_store::S3Store;
+use store::{Store, StoreManager};
+use verify_store::VerifyStore;
+
+pub fn store_factory<'a>(
+    backend: &'a StoreConfig,
+    store_manager: &'a Arc<StoreManager>,
+) -> Pin<Box<dyn Future<Output = Result<Arc<dyn Store>, Error>> + 'a>> {
+    Box::pin(async move {
+        let store: Arc<dyn Store> = match backend {
+            StoreConfig::memory(config) => Arc::new(MemoryStore::new(&config)),
+            StoreConfig::s3_store(config) => Arc::new(S3Store::new(&config)?),
+            StoreConfig::verify(config) => Arc::new(VerifyStore::new(
+                &config,
+                store_factory(&config.backend, store_manager).await?,
+            )),
+            StoreConfig::compression(config) => Arc::new(CompressionStore::new(
+                *config.clone(),
+                store_factory(&config.backend, store_manager).await?,
+            )?),
+            StoreConfig::dedup(config) => Arc::new(DedupStore::new(
+                &config,
+                store_factory(&config.index_store, store_manager).await?,
+                store_factory(&config.content_store, store_manager).await?,
+            )),
+            StoreConfig::fast_slow(config) => Arc::new(FastSlowStore::new(
+                &config,
+                store_factory(&config.fast, store_manager).await?,
+                store_factory(&config.slow, store_manager).await?,
+            )),
+            StoreConfig::filesystem(config) => Arc::new(FilesystemStore::new(&config).await?),
+            StoreConfig::ref_store(config) => Arc::new(RefStore::new(&config, store_manager.clone())),
+        };
+        Ok(store)
+    })
+}

--- a/cas/store/lib.rs
+++ b/cas/store/lib.rs
@@ -1,68 +1,32 @@
 // Copyright 2020-2021 Nathan (Blaise) Bruer.  All rights reserved.
 
 use std::collections::HashMap;
-use std::pin::Pin;
 use std::sync::Arc;
-
-use compression_store::CompressionStore;
-use config::{self, backends::StoreConfig};
-use dedup_store::DedupStore;
-use error::Error;
-use fast_slow_store::FastSlowStore;
-use filesystem_store::FilesystemStore;
-use futures::Future;
-use memory_store::MemoryStore;
-use s3_store::S3Store;
-use verify_store::VerifyStore;
+use std::sync::RwLock;
 
 pub use traits::{StoreTrait as Store, UploadSizeInfo};
 
 pub struct StoreManager {
-    stores: HashMap<String, Arc<dyn Store>>,
-}
-
-fn private_make_store<'a>(
-    backend: &'a StoreConfig,
-) -> Pin<Box<dyn Future<Output = Result<Arc<dyn Store>, Error>> + 'a>> {
-    Box::pin(async move {
-        let store: Arc<dyn Store> = match backend {
-            StoreConfig::memory(config) => Arc::new(MemoryStore::new(&config)),
-            StoreConfig::s3_store(config) => Arc::new(S3Store::new(&config)?),
-            StoreConfig::verify(config) => {
-                Arc::new(VerifyStore::new(&config, private_make_store(&config.backend).await?))
-            }
-            StoreConfig::compression(config) => Arc::new(CompressionStore::new(
-                *config.clone(),
-                private_make_store(&config.backend).await?,
-            )?),
-            StoreConfig::dedup(config) => Arc::new(DedupStore::new(
-                &config,
-                private_make_store(&config.index_store).await?,
-                private_make_store(&config.content_store).await?,
-            )),
-            StoreConfig::fast_slow(config) => Arc::new(FastSlowStore::new(
-                &config,
-                private_make_store(&config.fast).await?,
-                private_make_store(&config.slow).await?,
-            )),
-            StoreConfig::filesystem(config) => Arc::new(FilesystemStore::new(&config).await?),
-        };
-        Ok(store)
-    })
+    stores: RwLock<HashMap<String, Arc<dyn Store>>>,
 }
 
 impl StoreManager {
     pub fn new() -> StoreManager {
-        StoreManager { stores: HashMap::new() }
+        StoreManager {
+            stores: RwLock::new(HashMap::new()),
+        }
     }
 
-    pub async fn make_store(&mut self, name: &str, backend: &StoreConfig) -> Result<Arc<dyn Store>, Error> {
-        let store = private_make_store(backend).await?;
-        self.stores.insert(name.to_string(), store.clone());
-        Ok(store)
+    pub fn add_store(&self, name: &str, store: Arc<dyn Store>) {
+        let mut stores = self.stores.write().expect("Failed to lock mutex in add_store()");
+        stores.insert(name.to_string(), store);
     }
 
-    pub fn get_store(&self, name: &str) -> Option<&Arc<dyn Store>> {
-        self.stores.get(name)
+    pub fn get_store(&self, name: &str) -> Option<Arc<dyn Store>> {
+        let stores = self.stores.read().expect("Failed to lock read mutex in get_store()");
+        if let Some(store) = stores.get(name) {
+            return Some(store.clone());
+        }
+        return None;
     }
 }

--- a/cas/store/ref_store.rs
+++ b/cas/store/ref_store.rs
@@ -1,0 +1,107 @@
+// Copyright 2020-2021 Nathan (Blaise) Bruer.  All rights reserved.
+
+use std::cell::UnsafeCell;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
+use common::DigestInfo;
+use config;
+use error::{make_err, make_input_err, Code, Error};
+use store::StoreManager;
+use traits::{StoreTrait, UploadSizeInfo};
+
+#[repr(C, align(8))]
+struct AlignedStoreCell(UnsafeCell<Option<Arc<dyn StoreTrait>>>);
+
+struct StoreReference {
+    cell: AlignedStoreCell,
+    mux: Mutex<()>,
+}
+
+unsafe impl Sync for StoreReference {}
+
+pub struct RefStore {
+    ref_store_name: String,
+    store_manager: Arc<StoreManager>,
+    ref_store: StoreReference,
+}
+
+impl RefStore {
+    pub fn new(config: &config::backends::RefStore, store_manager: Arc<StoreManager>) -> Self {
+        RefStore {
+            ref_store_name: config.name.clone(),
+            store_manager,
+            ref_store: StoreReference {
+                mux: Mutex::new(()),
+                cell: AlignedStoreCell(UnsafeCell::new(None)),
+            },
+        }
+    }
+
+    // This will get the store or populate it if needed. It is designed to be quite fast on the
+    // common path, but slow on the uncommon path. It does use some unsafe functions because we
+    // wanted it to be fast. It is technically possible on some platforms for this function to
+    // create a data race here is the reason I do not believe it is an issue:
+    // 1. It would only happen on the very first call of the function (after first call we are safe)
+    // 2. It should only happen on platforms that are < 64 bit address space
+    // 3. It is likely that the internals of how Option work protect us anyway.
+    #[inline]
+    fn get_store(&self) -> Result<&Arc<dyn StoreTrait>, Error> {
+        let ref_store = self.ref_store.cell.0.get();
+        unsafe {
+            if let Some(ref store) = *ref_store {
+                return Ok(store);
+            }
+        }
+        // This should protect us against multiple writers writing the same location at the same
+        // time.
+        let _lock = self
+            .ref_store
+            .mux
+            .lock()
+            .map_err(|e| make_err!(Code::Internal, "Failed to lock mutex in ref_store : {:?}", e))?;
+        if let Some(store) = self.store_manager.get_store(&self.ref_store_name) {
+            unsafe {
+                *ref_store = Some(store.clone());
+                return Ok(&(*ref_store).as_ref().unwrap());
+            }
+        }
+        return Err(make_input_err!(
+            "Failed to find store '{}' in StoreManager in RefStore",
+            self.ref_store_name
+        ));
+    }
+}
+
+#[async_trait]
+impl StoreTrait for RefStore {
+    async fn has(self: Pin<&Self>, digest: DigestInfo) -> Result<Option<usize>, Error> {
+        let store = self.get_store()?;
+        Pin::new(store.as_ref()).has(digest).await
+    }
+
+    async fn update(
+        self: Pin<&Self>,
+        digest: DigestInfo,
+        reader: DropCloserReadHalf,
+        size_info: UploadSizeInfo,
+    ) -> Result<(), Error> {
+        let store = self.get_store()?;
+        Pin::new(store.as_ref()).update(digest, reader, size_info).await
+    }
+
+    async fn get_part(
+        self: Pin<&Self>,
+        digest: DigestInfo,
+        writer: DropCloserWriteHalf,
+        offset: usize,
+        length: Option<usize>,
+    ) -> Result<(), Error> {
+        let store = self.get_store()?;
+        Pin::new(store.as_ref()).get_part(digest, writer, offset, length).await
+    }
+}

--- a/cas/store/tests/ref_store_test.rs
+++ b/cas/store/tests/ref_store_test.rs
@@ -1,0 +1,116 @@
+// Copyright 2022 Nathan (Blaise) Bruer.  All rights reserved.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+#[cfg(test)]
+mod ref_store_tests {
+    use super::*;
+    use pretty_assertions::assert_eq; // Must be declared in every module.
+
+    use error::Error;
+
+    use common::DigestInfo;
+    use config;
+    use memory_store::MemoryStore;
+    use ref_store::RefStore;
+    use store::{Store, StoreManager};
+
+    const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
+
+    fn setup_stores() -> (Arc<MemoryStore>, Arc<RefStore>) {
+        let store_manager = Arc::new(StoreManager::new());
+
+        let memory_store_owned = Arc::new(MemoryStore::new(&config::backends::MemoryStore::default()));
+        store_manager.add_store("foo", memory_store_owned.clone());
+
+        let ref_store_owned = Arc::new(RefStore::new(
+            &config::backends::RefStore {
+                name: "foo".to_string(),
+            },
+            store_manager.clone(),
+        ));
+        store_manager.add_store("bar", ref_store_owned.clone());
+        (memory_store_owned, ref_store_owned)
+    }
+
+    #[tokio::test]
+    async fn has_test() -> Result<(), Error> {
+        let (memory_store_owned, ref_store_owned) = setup_stores();
+
+        const VALUE1: &str = "13";
+        {
+            // Insert data into memory store.
+            Pin::new(memory_store_owned.as_ref())
+                .update_oneshot(DigestInfo::try_new(&VALID_HASH1, VALUE1.len())?, VALUE1.into())
+                .await?;
+        }
+        {
+            // Now check if we check of ref_store has the data.
+            let has_result = Pin::new(ref_store_owned.as_ref())
+                .has(DigestInfo::try_new(&VALID_HASH1, VALUE1.len())?)
+                .await;
+            assert_eq!(
+                has_result,
+                Ok(Some(VALUE1.len())),
+                "Expected ref store to have data in ref store : {}",
+                VALID_HASH1
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_test() -> Result<(), Error> {
+        let (memory_store_owned, ref_store_owned) = setup_stores();
+
+        const VALUE1: &str = "13";
+        {
+            // Insert data into memory store.
+            Pin::new(memory_store_owned.as_ref())
+                .update_oneshot(DigestInfo::try_new(&VALID_HASH1, VALUE1.len())?, VALUE1.into())
+                .await?;
+        }
+        {
+            // Now check if we read it from ref_store it has same data.
+            let data = Pin::new(ref_store_owned.as_ref())
+                .get_part_unchunked(DigestInfo::try_new(&VALID_HASH1, VALUE1.len())?, 0, None, None)
+                .await
+                .expect("Get should have succeeded");
+            assert_eq!(
+                data,
+                VALUE1.as_bytes(),
+                "Expected ref store to have data in ref store : {}",
+                VALID_HASH1
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update_test() -> Result<(), Error> {
+        let (memory_store_owned, ref_store_owned) = setup_stores();
+
+        const VALUE1: &str = "13";
+        {
+            // Insert data into ref_store.
+            Pin::new(ref_store_owned.as_ref())
+                .update_oneshot(DigestInfo::try_new(&VALID_HASH1, VALUE1.len())?, VALUE1.into())
+                .await?;
+        }
+        {
+            // Now check if we read it from memory_store it has same data.
+            let data = Pin::new(memory_store_owned.as_ref())
+                .get_part_unchunked(DigestInfo::try_new(&VALID_HASH1, VALUE1.len())?, 0, None, None)
+                .await
+                .expect("Get should have succeeded");
+            assert_eq!(
+                data,
+                VALUE1.as_bytes(),
+                "Expected ref store to have data in memory store : {}",
+                VALID_HASH1
+            );
+        }
+        Ok(())
+    }
+}

--- a/config/backends.rs
+++ b/config/backends.rs
@@ -85,6 +85,19 @@ pub enum StoreConfig {
     /// swap files if a file is being replaced. Only filesystems that
     /// support `atime` and the RENAME_EXCHANGE flag are supported.
     filesystem(FilesystemStore),
+
+    /// Store used to reference a store in the root store manager.
+    /// This is useful for cases when you want to share a store in different
+    /// nested stores. Example, you may want to share the same memory store
+    /// used for the action cache, but use a FastSlowStore and have the fast
+    /// store also share the memory store for efficiency.
+    ref_store(RefStore),
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct RefStore {
+    /// Name of the store under the root "stores" config object.
+    pub name: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/config/examples/filesystem_cas.json
+++ b/config/examples/filesystem_cas.json
@@ -1,5 +1,22 @@
 {
   "stores": {
+    "FS_CONTENT_STORE": {
+      "compression": {
+        "compression_algorithm": {
+          "LZ4": {}
+        },
+        "backend": {
+          "filesystem": {
+            "content_path": "/tmp/rust_cas_data/content_path-cas",
+            "temp_path": "/tmp/rust_cas_data/tmp_path-cas",
+            "eviction_policy": {
+              // 2gb.
+              "max_bytes": 2000000000,
+            }
+          }
+        }
+      }
+    },
     "CAS_MAIN_STORE": {
       "verify": {
         "backend": {
@@ -15,20 +32,8 @@
               }
             },
             "content_store": {
-              "compression": {
-                "compression_algorithm": {
-                  "LZ4": {}
-                },
-                "backend": {
-                  "filesystem": {
-                    "content_path": "/tmp/rust_cas_data/content_path-cas",
-                    "temp_path": "/tmp/rust_cas_data/tmp_path-cas",
-                    "eviction_policy": {
-                      // 2gb.
-                      "max_bytes": 2000000000,
-                    }
-                  }
-                }
+              "ref_store": {
+                "name": "FS_CONTENT_STORE"
               }
             }
           }


### PR DESCRIPTION
Adds new RefStore. This store is used so you can reference another
store in the json / StoreManager by name. This will allow users
to reference the same store from multiple places.

Also restructures StoreManager to allow for this new functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/rust_cas/44)
<!-- Reviewable:end -->
